### PR TITLE
rebase to arch

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue.bug.yml
@@ -52,6 +52,7 @@ body:
       label: CPU architecture
       options:
         - x86-64
+        - arm64
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,7 +29,7 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`kdenlive_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -s 'https://apps.kde.org/kdenlive/index.xml' | awk -F'[<>]' '{for(i=1; i<=NF; i++) if($i=="guid"){split($(i+1), a, "#"); print a[2]; exit}}')
+          EXT_RELEASE=$(curl -sL https://archlinux.org/packages/extra/x86_64/kdenlive/ |awk -F'(<h2>kdenlive |</h2>)' '/<h2>/ {print $2}')
           echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^kdenlive_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:arch
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-arch
 
 # set version label
 ARG BUILD_DATE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
     DOCKERHUB_IMAGE = 'linuxserver/kdenlive'
     DEV_DOCKERHUB_IMAGE = 'lsiodev/kdenlive'
     PR_DOCKERHUB_IMAGE = 'lspipepr/kdenlive'
-    DIST_IMAGE = 'ubuntu'
-    MULTIARCH = 'false'
+    DIST_IMAGE = 'arch'
+    MULTIARCH = 'true'
     CI = 'true'
     CI_WEB = 'true'
     CI_PORT = '3001'
@@ -147,7 +147,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -s 'https://apps.kde.org/kdenlive/index.xml' | awk -F'[<>]' '{for(i=1; i<=NF; i++) if($i=="guid"){split($(i+1), a, "#"); print a[2]; exit}}' ''',
+            script: ''' curl -sL https://archlinux.org/packages/extra/x86_64/kdenlive/ |awk -F'(<h2>kdenlive |</h2>)' '/<h2>/ {print $2}' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/README.md
+++ b/README.md
@@ -52,13 +52,12 @@ The architectures supported by this image are:
 | Architecture | Available | Tag |
 | :----: | :----: | ---- |
 | x86-64 | ✅ | amd64-\<version tag\> |
-| arm64 | ❌ | |
+| arm64 | ✅ | arm64v8-\<version tag\> |
 
 ## Application Setup
 
 The application can be accessed at:
 
-* http://yourhost:3000/
 * https://yourhost:3001/
 
 ### Strict reverse proxies
@@ -221,8 +220,6 @@ services:
   kdenlive:
     image: lscr.io/linuxserver/kdenlive:latest
     container_name: kdenlive
-    security_opt:
-      - seccomp:unconfined #optional
     environment:
       - PUID=1000
       - PGID=1000
@@ -241,7 +238,6 @@ services:
 ```bash
 docker run -d \
   --name=kdenlive \
-  --security-opt seccomp=unconfined `#optional` \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
@@ -266,7 +262,6 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-v /config` | Users home directory in the container, stores local files and settings |
 | `--shm-size=` | This might be needed to prevent crashing |
-| `--security-opt seccomp=unconfined` | For Docker Engine only, this may be required depending on your Docker and storage configuration. |
 
 ## Environment variables from files (Docker secrets)
 
@@ -430,6 +425,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **22.09.25:** - Rebase to Arch latest Appimage no longer working on Deb distros. Build for arm64 again.
 * **06.08.25:** - Fix cpu bug, disable gamepad by default.
 * **12.07.25:** - Rebase to Selkies and use official AppImage, HTTPS IS NOW REQUIRED. Remove arm64 support.
 * **19.08.24:** - Rebase to noble. Use pypi and lsio wheels.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,9 +2,9 @@
 
 # jenkins variables
 project_name: docker-kdenlive
-external_type: nai
+external_type: na
 custom_version_command: |-
-  curl -s 'https://apps.kde.org/kdenlive/index.xml' | awk -F'[<>]' '{for(i=1; i<=NF; i++) if($i=="guid"){split($(i+1), a, "#"); print a[2]; exit}}'
+  curl -sL https://archlinux.org/packages/extra/x86_64/kdenlive/ |awk -F'(<h2>kdenlive |</h2>)' '/<h2>/ {print $2}'
 release_type: stable
 release_tag: latest
 ls_branch: master
@@ -17,8 +17,8 @@ repo_vars:
   - DOCKERHUB_IMAGE = 'linuxserver/kdenlive'
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/kdenlive'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/kdenlive'
-  - DIST_IMAGE = 'ubuntu'
-  - MULTIARCH = 'false'
+  - DIST_IMAGE = 'arch'
+  - MULTIARCH = 'true'
   - CI = 'true'
   - CI_WEB = 'true'
   - CI_PORT = '3001'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -11,6 +11,7 @@ project_blurb_optional_extras_enabled: false
 # supported architectures
 available_architectures:
   - {arch: "{{ arch_x86_64 }}", tag: "latest"}
+  - {arch: "{{ arch_arm64 }}", tag: "arm64v8-latest"}
 # development version
 development_versions: false
 # container parameters
@@ -25,9 +26,6 @@ param_ports:
   - {external_port: "3001", internal_port: "3001", port_desc: "Kdenlive desktop gui HTTPS."}
 opt_custom_params:
   - {name: "shm-size", name_compose: "shm_size", value: "1gb", desc: "This might be needed to prevent crashing"}
-opt_security_opt_param: true
-opt_security_opt_param_vars:
-  - {run_var: "seccomp=unconfined", compose_var: "seccomp:unconfined", desc: "For Docker Engine only, this may be required depending on your Docker and storage configuration."}
 # Selkies blurb settings
 selkies_blurb: true
 show_nvidia: true
@@ -36,7 +34,6 @@ app_setup_block_enabled: true
 app_setup_block: |
   The application can be accessed at:
 
-  * http://yourhost:3000/
   * https://yourhost:3001/
 # init diagram
 init_diagram: |
@@ -108,6 +105,7 @@ init_diagram: |
   "kdenlive:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "22.09.25:", desc: "Rebase to Arch latest Appimage no longer working on Deb distros. Build for arm64 again."}
   - {date: "06.08.25:", desc: "Fix cpu bug, disable gamepad by default."}
   - {date: "12.07.25:", desc: "Rebase to Selkies and use official AppImage, HTTPS IS NOW REQUIRED. Remove arm64 support."}
   - {date: "19.08.24:", desc: "Rebase to noble. Use pypi and lsio wheels."}

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-kdenlive
+dbus-launch kdenlive

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
-<item label="Kdenlive" icon="/opt/kdenlive/usr/share/icons/hicolor/48x48/apps/kdenlive.png"><action name="Execute"><command>/usr/bin/kdenlive</command></action></item>
+<item label="Kdenlive" icon="/usr/share/icons/hicolor/32x32/apps/kdenlive.png"><action name="Execute"><command>dbus-launch /usr/bin/kdenlive</command></action></item>
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
 </menu>
 </openbox_menu>

--- a/root/usr/bin/kdenlive
+++ b/root/usr/bin/kdenlive
@@ -1,4 +1,0 @@
-#! /bin/bash
-
-cd /opt/kdenlive
-./AppRun


### PR DESCRIPTION
So they stopped updating their PPA and went to appimage being the only thing we could ingest and now those appimages need namespacing so they are out for docker usage so to keep current Arch is the only option. We also get back arm support with this. 

The current head image is broken and non op, this is the best solution I have without going back in time on versioning. 